### PR TITLE
Fixing some missing references and typos

### DIFF
--- a/WebProject/Controllers/Misc/HttpErrorPageController.cs
+++ b/WebProject/Controllers/Misc/HttpErrorPageController.cs
@@ -1,6 +1,5 @@
-﻿using System.Web.Mvc;
-using EPiServer;
-using EPiServer.Core;
+﻿using System.Net;
+using System.Web.Mvc;
 using WebProject.Utils;
 using WebProject.Redirects;
 

--- a/WebProject/Utils/StringExtensions.cs
+++ b/WebProject/Utils/StringExtensions.cs
@@ -15,4 +15,3 @@ namespace WebProject.Utils
         }
     }
 }
-}

--- a/WebProject/Views/Admin/RedirectManager.cshtml
+++ b/WebProject/Views/Admin/RedirectManager.cshtml
@@ -3,6 +3,7 @@
 @using EPiServer.Shell.Navigation
 @using EPiServer.ServiceLocation
 @using WebProject.Redirects
+@using WebProject.Utils
 @{ OnLoad(); }
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Fixing couple of issues:
1. There's additional `}` in `StringExtensions`
2. `System.Net` is missing in `HtmlErrorController` (without that [HttpStatusCode](https://github.com/huilaaja/RedirectManager/blob/master/WebProject/Controllers/Misc/HttpErrorPageController.cs#L28) is an unknown class
3. `WebProject.Utils` is missing in `RedirectManager.cshtml`. You need to import that in order to use [ParseIntOrDefault](https://github.com/huilaaja/RedirectManager/blob/master/WebProject/Views/Admin/RedirectManager.cshtml#L232) method