### PR TITLE
Replace less-than and greater-than with html entities in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It requires only 4 files for business logic and data access, 1 controller and 1 
 
 <h2>Auto wire up</h2>
 <p>You can automatically populate the RedirectManager with data on following events from editors, moving pages in structure, renaming url segment and deleting from Waste Basket. Just put this in your InitializableModule: <br/>
-  <pre>var events = ServiceLocator.Current.GetInstance<IContentEvents>();
+  <pre>var events = ServiceLocator.Current.GetInstance&lt;ContentEvents&gt;();
             events.MovingContent += RedirectKeeper.Page_Moving;
             events.PublishingContent += RedirectKeeper.UrlSegment_Changed;
             events.DeletedContent += RedirectKeeper.Page_Deleted;</pre>


### PR DESCRIPTION
Make the «ServiceLocator.Current.GetInstance **&lt;IContentEvents&gt;** ()» visible in the code example in readme.