### PR TITLE
Remove trailing slash from fromurl, as this will never match because this is removed in GetPrimaryRedirectUrlOrDefault

### DIFF
--- a/WebProject/Views/Admin/RedirectManager.cshtml
+++ b/WebProject/Views/Admin/RedirectManager.cshtml
@@ -241,7 +241,7 @@
         {
             int n = RedirectService.AddRedirect(Request.Params["sortorder"].ParseIntOrDefault(),
                                                 Request.Params["host"],
-                                                Request.Params["fromurl"],
+                                                Request.Params["fromurl"].Trim().TrimEnd('/'),
                                                 Request.Params["wildcard"].ParseBoolOrDefault(),
                                                 Request.Params["tourl"],
                                                 Request.Params["tocontentid"].ParseIntOrDefault(),
@@ -257,7 +257,7 @@
             int n = RedirectService.ModifyRedirect(CurrentRedirect.Id,
                                                     Request.Params["sortorder"].ParseIntOrDefault(),
                                                     Request.Params["host"],
-                                                    Request.Params["fromurl"],
+                                                    Request.Params["fromurl"].Trim().TrimEnd('/'),
                                                     Request.Params["wildcard"].ParseBoolOrDefault(),
                                                     Request.Params["tourl"],
                                                     Request.Params["tocontentid"].ParseIntOrDefault(),


### PR DESCRIPTION
Because trailing slash of the requested url is removed in GetPrimaryRedirectUrlOrDefault, creating redirects where fromurl ends with a trailing slash (/) will not be hit. It is common for editors to copy the url (that ends with a trailing slash).